### PR TITLE
Ensure stdout is printed before errors

### DIFF
--- a/kharma/b_cd/b_cd.cpp
+++ b/kharma/b_cd/b_cd.cpp
@@ -109,6 +109,7 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
 
     // Throw down here, like this, to avoid inaccessible code warnings
     if (1) {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Constraint-damping transport is not functional with modern B field initialization!");
     } else {
         return pkg;

--- a/kharma/b_cleanup/b_cleanup.cpp
+++ b/kharma/b_cleanup/b_cleanup.cpp
@@ -50,8 +50,10 @@
 
 // The package should never be loaded if there is not a global solve to be done.
 // Therefore we yell at load time rather than waiting for the first solve
-std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
-{throw std::runtime_error("KHARMA was compiled without global solvers!  Cannot clean B Field!");}
+std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages) {
+    std::cout << std::endl; // flush messages in output buffer before we error
+    throw std::runtime_error("KHARMA was compiled without global solvers!  Cannot clean B Field!");
+}
 // We still need a stub for CleanupDivergence() in order to compile, but it will never be called
 TaskStatus B_Cleanup::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md) {}
 bool B_Cleanup::CleanupThisStep(Mesh* pmesh, int nstep) {}
@@ -165,6 +167,8 @@ std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(ParameterInput *pin, std::s
 
     if (manage_field) {
         // Copy in the field initialization from B_CT and/or B_FluxCT here to declare the right stuff
+
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("B field cleanup/projection is set as B field transport! This is not implemented!");
     }
 

--- a/kharma/b_ct/b_ct.cpp
+++ b/kharma/b_ct/b_ct.cpp
@@ -71,8 +71,10 @@ std::shared_ptr<KHARMAPackage> B_CT::Initialize(ParameterInput *pin, std::shared
     // This relies entirely on the EMF communication for preserving the divergence
     bool lazy_prolongation = pin->GetOrAddBoolean("b_field", "lazy_prolongation", false);
     // Need to preserve divergence if you refine/derefine during sim i.e. AMR
-    if (lazy_prolongation && pin->GetString("parthenon/mesh", "refinement") == "adaptive")
+    if (lazy_prolongation && pin->GetString("parthenon/mesh", "refinement") == "adaptive") {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Cannot use non-divergence-preserving prolongation in AMR!");
+    }
 
     // TODO don't set this unless we're reconnecting at boundaries (can't just check, we load Boundaries pkg later)
     int reconnection_outer_buffer = pin->GetOrAddBoolean("b_field", "reconnection_outer_buffer", 5);
@@ -287,7 +289,10 @@ TaskStatus B_CT::CalculateEMF(MeshData<Real> *md)
 {
     auto pmesh = md->GetMeshPointer();
     const int ndim = pmesh->ndim;
-    if (ndim < 2) throw std::runtime_error("Face-centered constrained transport does not support 1D! Use `flux_ct` instead.");
+    if (ndim < 2) {
+        std::cout << std::endl; // flush messages in output buffer before we error
+        throw std::runtime_error("Face-centered constrained transport does not support 1D! Use `flux_ct` instead.");
+    }
 
     // EMF temporary
     auto& emf_pack = md->PackVariables(std::vector<std::string>{"B_CT.emf"});
@@ -742,8 +747,10 @@ TaskStatus B_CT::PrintGlobalMaxDivB(MeshData<Real> *md, bool kill_on_large_divb)
             printf("Max DivB: %g\n", divb_max); // someday I'll learn stream options
         }
         if (kill_on_large_divb) {
-            if (divb_max > pmb0->packages.Get("B_CT")->Param<Real>("kill_on_divb_over"))
+            if (divb_max > pmb0->packages.Get("B_CT")->Param<Real>("kill_on_divb_over")) {
+                std::cout << std::endl; // flush messages in output buffer before we error
                 throw std::runtime_error("DivB exceeds maximum! Quitting...");
+            }
         }
     }
 

--- a/kharma/b_flux_ct/b_flux_ct.cpp
+++ b/kharma/b_flux_ct/b_flux_ct.cpp
@@ -640,8 +640,10 @@ TaskStatus PrintGlobalMaxDivB(MeshData<Real> *md, bool kill_on_large_divb)
             printf("Max DivB: %g\n", divb_max);
         }
         if (kill_on_large_divb) {
-            if (divb_max > pmb0->packages.Get("B_FluxCT")->Param<Real>("kill_on_divb_over"))
+            if (divb_max > pmb0->packages.Get("B_FluxCT")->Param<Real>("kill_on_divb_over")) {
+                std::cout << std::endl; // flush messages in output buffer before we error
                 throw std::runtime_error("DivB exceeds maximum! Quitting...");
+            }
         }
     }
 

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -73,6 +73,7 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
     params.Add("zero_polar_flux", zero_polar_flux);
     // Throw an error if both are set
     if (excise_polar_flux && zero_polar_flux) {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Cannot set both boundaries/excise_polar_flux and boundaries/zero_polar_flux!");
     }
 
@@ -301,6 +302,7 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
                     break;
                 }
                 if (pin->GetString("coordinates", "transform") == "fmks" || pin->GetString("coordinates", "transform") == "funky")
+                    std::cout << std::endl; // flush messages in output buffer before we error
                     throw std::runtime_error("Transmitting polar boundary conditions require coordinates symmetric about theta=0!");
                 // TODO also check for wedge simulations x3<2pi
             } else if (btype == "outflow") {
@@ -352,6 +354,7 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
                     break;
                 }
             } else {
+                std::cout << std::endl; // flush messages in output buffer before we error
                 throw std::runtime_error("Unknown boundary type: "+btype);
             }
         }
@@ -361,12 +364,15 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
     if (pin->GetInteger("parthenon/mesh", "nx3") != pin->GetInteger("parthenon/meshblock", "nx3") ||
         pin->GetInteger("parthenon/mesh", "nx3") == 1) {
         if (pin->GetString("boundaries", "inner_x3") == "transmitting" || pin->GetString("boundaries", "outer_x3") == "transmitting")
+            std::cout << std::endl; // flush messages in output buffer before we error
             throw std::runtime_error("Transmitting polar boundary conditions require 3D with one block in x3!");
         if (params.Get<bool>("cancel_U3_inner_x3") || params.Get<bool>("cancel_U3_outer_x3") ||
             params.Get<bool>("cancel_T3_inner_x3") || params.Get<bool>("cancel_T3_outer_x3"))
+            std::cout << std::endl; // flush messages in output buffer before we error
             throw std::runtime_error("Polar cancellations require 3D with one block in x3!");
         if (packages->AllPackages().count("B_CT") &&
             (params.Get<bool>("reconnect_B3_inner_x3") || params.Get<bool>("reconnect_B3_outer_x3")))
+            std::cout << std::endl; // flush messages in output buffer before we error
             throw std::runtime_error("Polar reconnections require 3D with one block in x3!");
     }
 
@@ -704,6 +710,7 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
             if (params.Get<bool>("excise_flux_" + bname)) {
                 // ...and if this face of the block corresponds to a global boundary...
                 if (IsPhysicalBoundary(pmb, bface)) {
+                    std::cout << std::endl; // flush messages in output buffer before we error
                     if (bdir != 2) throw std::runtime_error("Excised polar fluxes only fully implemented in X2!");
 
                     // Pack w/B to match indices with the `Flux.X` below
@@ -893,6 +900,7 @@ void KBoundaries::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDoma
             if (params.Get<bool>("excise_flux_" + bname)) {
                 // ...and if this face of the block corresponds to a global boundary...
                 if (IsPhysicalBoundary(pmb, bface)) {
+                    std::cout << std::endl; // flush messages in output buffer before we error
                     if (bdir != 2) throw std::runtime_error("Excised polar fluxes only fully implemented in X2!");
 
                     const IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior);

--- a/kharma/boundaries/boundary_types.hpp
+++ b/kharma/boundaries/boundary_types.hpp
@@ -150,6 +150,7 @@ inline IndexDomain BoundaryDomain(const BoundaryFace face)
         return IndexDomain::outer_x3;
     case BoundaryFace::undef:
     default:
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Undefined boundary face has no domain!");
     }
 }

--- a/kharma/boundaries/one_block_transmit.cpp
+++ b/kharma/boundaries/one_block_transmit.cpp
@@ -74,8 +74,10 @@ void KBoundaries::TransmitSetTE(MeshBlockData<Real> *rc, VariablePack<Real> &q, 
     const auto domain = BoundaryDomain(bface);
     const auto bname = BoundaryName(bface);
 
-    if (bdir != 2)
+    if (bdir != 2) {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Transmitting polar conditions only defined for X2!");
+    }
 
     std::vector<TopologicalElement> el_list;
     if (do_face) {

--- a/kharma/coordinates/coordinate_embedding.hpp
+++ b/kharma/coordinates/coordinate_embedding.hpp
@@ -133,7 +133,10 @@ class CoordinateEmbedding {
                 GReal a = pin->GetReal("coordinates", "a");
                 bool ext_g = pin->GetOrAddBoolean("coordinates", "ext_g", false);
                 if (ext_g || base_str == "spherical_ks_extg" || base_str == "ks_extg") {
-                    if (a > 0) throw std::invalid_argument("Transform is for spherical coordinates!");
+                    if (a > 0) {
+                        std::cout << std::endl; // flush messages in output buffer before we error
+                        throw std::invalid_argument("Transform is for spherical coordinates!");
+                    }
                     base.emplace<SphKSExtG>(SphKSExtG(a));
                 } else {
                     base.emplace<SphKSCoords>(SphKSCoords(a));
@@ -143,12 +146,16 @@ class CoordinateEmbedding {
                 GReal a = pin->GetReal("coordinates", "a");
                 bool ext_g = pin->GetOrAddBoolean("coordinates", "ext_g", false);
                 if (ext_g || base_str == "spherical_bl_extg" || base_str == "bl_extg") {
-                    if (a > 0) throw std::invalid_argument("Transform is for spherical coordinates!");
+                    if (a > 0) {
+                        std::cout << std::endl; // flush messages in output buffer before we error
+                        throw std::invalid_argument("Transform is for spherical coordinates!");
+                    }
                     base.emplace<SphBLExtG>(SphBLExtG(a));
                 } else {
                     base.emplace<SphBLCoords>(SphBLCoords(a));
                 }
             } else {
+                std::cout << std::endl; // flush messages in output buffer before we error
                 throw std::invalid_argument("Unsupported base coordinates!");
             }
 
@@ -161,20 +168,32 @@ class CoordinateEmbedding {
                     transform.emplace<NullTransform>(NullTransform());
                 }
             } else if (transform_str == "exponential" || transform_str == "exp" || transform_str == "eks") {
-                if (!spherical) throw std::invalid_argument("Transform is for spherical coordinates!");
+                if (!spherical) {
+                    std::cout << std::endl; // flush messages in output buffer before we error
+                    throw std::invalid_argument("Transform is for spherical coordinates!");
+                }
                 transform.emplace<ExponentialTransform>(ExponentialTransform());
             } else if (transform_str == "superexponential" || transform_str == "superexp") {
-                if (!spherical) throw std::invalid_argument("Transform is for spherical coordinates!");
+                if (!spherical) {
+                    std::cout << std::endl; // flush messages in output buffer before we error
+                    throw std::invalid_argument("Transform is for spherical coordinates!");
+                }
                 GReal r_br = pin->GetOrAddReal("coordinates", "r_br", 1000.);
                 GReal npow = pin->GetOrAddReal("coordinates", "npow", 1.0);
                 GReal cpow = pin->GetOrAddReal("coordinates", "cpow", 4.0);
                 transform.emplace<SuperExponentialTransform>(SuperExponentialTransform(r_br, npow, cpow));
             } else if (transform_str == "modified" || transform_str == "mks") {
-                if (!spherical) throw std::invalid_argument("Transform is for spherical coordinates!");
+                if (!spherical) {
+                    std::cout << std::endl; // flush messages in output buffer before we error
+                    throw std::invalid_argument("Transform is for spherical coordinates!");
+                }
                 GReal hslope = pin->GetOrAddReal("coordinates", "hslope", 0.3);
                 transform.emplace<ModifyTransform>(ModifyTransform(hslope));
             } else if (transform_str == "funky" || transform_str == "fmks") {
-                if (!spherical) throw std::invalid_argument("Transform is for spherical coordinates!");
+                if (!spherical) {
+                    std::cout << std::endl; // flush messages in output buffer before we error
+                    throw std::invalid_argument("Transform is for spherical coordinates!");
+                }
                 GReal hslope = pin->GetOrAddReal("coordinates", "hslope", 0.3);
                 GReal mks_smooth = pin->GetOrAddReal("coordinates", "mks_smooth", 0.5);
                 GReal poly_xt = pin->GetOrAddReal("coordinates", "poly_xt", 0.82);
@@ -190,13 +209,17 @@ class CoordinateEmbedding {
                 }
                 transform.emplace<FunkyTransform>(FunkyTransform(startx1, hslope, mks_smooth, poly_xt, poly_alpha));
             } else if (transform_str == "widepole" || transform_str == "wks") {
-                if (!spherical) throw std::invalid_argument("Transform is for spherical coordinates!");
+                if (!spherical) {
+                    std::cout << std::endl; // flush messages in output buffer before we error
+                    throw std::invalid_argument("Transform is for spherical coordinates!");
+                }
                 GReal lin_frac = pin->GetOrAddReal("coordinates", "lin_frac", 0.6);
                 GReal smoothness = pin->GetOrAddReal("coordinates", "smoothness", -1.0);
                 GReal nx2 = pin->GetReal("parthenon/mesh", "nx2");
                 GReal nx3 = pin->GetReal("parthenon/mesh", "nx3");
                 transform.emplace<WidepoleTransform>(WidepoleTransform(lin_frac, smoothness, nx2, nx3));
             } else {
+                std::cout << std::endl; // flush messages in output buffer before we error
                 throw std::invalid_argument("Unsupported coordinate transform!");
             }
         }

--- a/kharma/driver/kharma_driver.cpp
+++ b/kharma/driver/kharma_driver.cpp
@@ -275,6 +275,7 @@ TaskID KHARMADriver::AddFluxCalculations(TaskID& t_start, TaskList& tl, MeshData
         t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::mp5, X3DIR>, md);
         break;
     default:
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::invalid_argument("Unsupported reconstruction algorithm! Main supported algorithms: linear_mc, weno5, weno5_linear");
     }
     auto t_calc_fluxes = t_calculate_flux1 | t_calculate_flux2 | t_calculate_flux3;

--- a/kharma/driver/simple_step.cpp
+++ b/kharma/driver/simple_step.cpp
@@ -50,7 +50,10 @@ TaskCollection KHARMADriver::MakeSimpleTaskCollection(BlockList_t &blocks, int s
         pkgs.count("Electrons") || flux_pkg.Get<bool>("use_fofc") ||
         pkgs.count("Implicit") || pkgs.count("Current") ||
         pkgs.count("EMHD") || pkgs.count("ISMR") || pmesh->multilevel)
+    {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Simple driver cannot be used with any advanced features! Use KHARMA or ImEx driver instead!");
+    }
 
     // Allocate the fluid states ("containers") we need for each block
     if (stage == 1) {

--- a/kharma/electrons/gaussian.cpp
+++ b/kharma/electrons/gaussian.cpp
@@ -117,6 +117,7 @@ void create_grf(int Nx1, int Nx2, double lx1, double lx2,
 void create_grf(int Nx1, int Nx2, double lx1, double lx2, 
                     double * dv1, double * dv2)
 {
+    std::cout << std::endl; // flush messages in output buffer before we error
     throw std::runtime_error("Attempted to use an FFT to generate a Gaussian random field, but KHARMA was compiled without FFT support!");
 }
 #endif

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -283,6 +283,7 @@ TaskStatus Floors::ApplyGRMHDFloors(MeshData<Real> *md, IndexDomain domain)
     } else if (pars.Get<InjectionFrame>("frame") == InjectionFrame::drift) {
         return ApplyFloorsInFrame<InjectionFrame::drift>(md, domain);
     } else {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::invalid_argument("Floors for requested frame not implemented!");
     }
 }

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -95,6 +95,7 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
                       << "The resulting algorithm is much more stable, but requires that floors be applied in the normal observer frame.\n"
                       << "Consider using the <floors> parameters from pars/tori_3d/mad.par.\n"
                       << "If you know what you're doing, set floors/allow_unsafe=true";
+            std::cout << std::endl; // flush messages in output buffer before we error
             throw std::runtime_error("Unsafe floors requested without override");
         }
     }

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -77,10 +77,14 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
     std::string recon = pin->GetOrAddString("flux", "reconstruction", default_recon_s, recon_allowed_vals);
     bool lower_edges = pin->GetOrAddBoolean("flux", "low_order_edges", false);
     bool lower_poles = pin->GetOrAddBoolean("flux", "low_order_poles", false);
-    if (lower_edges && lower_poles)
+    if (lower_edges && lower_poles) {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Cannot enable lowered reconstruction on edges and poles!");
-    if ((lower_edges || lower_poles) && recon != "weno5")
+    }
+    if ((lower_edges || lower_poles) && recon != "weno5") {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Lowered reconstructions can only be enabled with weno5!");
+    }
 
     int stencil = 0;
     if (recon == "donor_cell") {
@@ -122,6 +126,7 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
     // Warn if using less than 3 ghost zones w/WENO etc, 2 w/Linear, etc.
     // SMR/AMR independently requires an even number of zones, so we usually use 4
     if (Globals::nghost < (stencil/2 + 1)) {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Not enough ghost zones for specified reconstruction!");
     }
 
@@ -484,6 +489,7 @@ TaskStatus Flux::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
         if (MPIRank0() && (nzero > 0 || nnan > 0)) {
             // TODO string formatting in C++ that doesn't suck
             fprintf(stderr, "Max signal speed ctop of 0 or NaN (%d zero, %d NaN)", nzero, nnan);
+            std::cout << std::endl; // flush messages in output buffer before we error
             throw std::runtime_error("Bad ctop!");
         }
 

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -515,7 +515,10 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const bool binner = KBoundaries::BoundaryIsInner(bface);
     const auto bname = KBoundaries::BoundaryName(bface);
     const auto bdir = KBoundaries::BoundaryDirection(bface);
-    if (bdir != 2) throw std::runtime_error("T3 Cancellation is only implemented for polar X2 boundaries!");
+    if (bdir != 2) {
+        std::cout << std::endl; // flush messages in output buffer before we error
+        throw std::runtime_error("T3 Cancellation is only implemented for polar X2 boundaries!");
+    }
 
     // Pull variables (TODO take packs & maps, see boundaries.cpp)
     PackIndexMap prims_map, cons_map;
@@ -590,7 +593,10 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const bool binner = KBoundaries::BoundaryIsInner(bface);
     const auto bname = KBoundaries::BoundaryName(bface);
     const auto bdir = KBoundaries::BoundaryDirection(bface);
-    if (bdir != 2) throw std::runtime_error("T3 Cancellation is only implemented for polar X2 boundaries!");
+    if (bdir != 2) {
+        std::cout << std::endl; // flush messages in output buffer before we error
+        throw std::runtime_error("T3 Cancellation is only implemented for polar X2 boundaries!");
+    }
 
     // Pull variables (TODO take packs & maps, see boundaries.cpp)
     PackIndexMap prims_map, cons_map;

--- a/kharma/implicit/implicit.cpp
+++ b/kharma/implicit/implicit.cpp
@@ -46,7 +46,10 @@
 // The package should never be loaded if there are not implicitly-evolved variables
 // Therefore we yell at load time rather than waiting for the first solve
 std::shared_ptr<KHARMAPackage> Implicit::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
-{ throw std::runtime_error("KHARMA was compiled without implicit stepping support!"); }
+{
+    std::cout << std::endl; // flush messages in output buffer before we error
+    throw std::runtime_error("KHARMA was compiled without implicit stepping support!");
+}
 // We still need a stub for Step() in order to compile, but it will never be called
 TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_sub_step_init, MeshData<Real> *md_flux_src,
                 MeshData<Real> *md_linesearch, MeshData<Real> *md_solver, const Real& dt) {}

--- a/kharma/ismr/ismr.cpp
+++ b/kharma/ismr/ismr.cpp
@@ -47,8 +47,10 @@ std::shared_ptr<KHARMAPackage> ISMR::Initialize(ParameterInput *pin, std::shared
     // TODO add "poles" specifically if we ever support other areas
     uint nlevels = (uint) pin->GetOrAddInteger("ismr", "nlevels", 1);
     params.Add("nlevels", nlevels);
-    if (nlevels < 1)
+    if (nlevels < 1) {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Internal SMR requires a positive number of levels!");
+    }
 
     // ISMR cache: not evolved, immediately copied to fluid state after averaging
     // Must be total size of variable list
@@ -60,8 +62,10 @@ std::shared_ptr<KHARMAPackage> ISMR::Initialize(ParameterInput *pin, std::shared
     pkg->AddField("ismr.vars_avg", m);
 
     // Incompatible with B_FluxCT due to non-local divB, yell
-    if (packages->AllPackages().count("B_FluxCT"))
+    if (packages->AllPackages().count("B_FluxCT")) {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Internal SMR is not compatible with Flux-CT magnetic field transport!");
+    }
     // Otherwise declare a face temporary
     if (packages->AllPackages().count("B_CT")) {
         m = Metadata({Metadata::Real, Metadata::Face, Metadata::Derived, Metadata::OneCopy});
@@ -69,8 +73,10 @@ std::shared_ptr<KHARMAPackage> ISMR::Initialize(ParameterInput *pin, std::shared
     }
 
     // Incompatible with 2D simulations
-    if (pin->GetInteger("parthenon/meshblock", "nx3") == 1)
+    if (pin->GetInteger("parthenon/meshblock", "nx3") == 1) {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Internal SMR is not compatible with 2D blocks or meshes!");
+    }
 
     // TODO register a split-operator callback?
 

--- a/kharma/kharma.cpp
+++ b/kharma/kharma.cpp
@@ -220,6 +220,7 @@ void KHARMA::FixParameters(ParameterInput *pin, bool is_parthenon_restart)
                     // then we want xeh = xin + 5.5 * (xout - xin) / N1TOT:
                     const GReal x1min = (nx1 * x1hor / 5.5 - x1max) / (-1. + nx1 / 5.5);
                     if (x1min < 0.0) {
+                        std::cout << std::endl; // flush messages in output buffer before we error
                         throw std::invalid_argument("Not enough radial zones were specified to put 5 zones inside EH!");
                     }
                     pin->GetOrAddReal("parthenon/mesh", "x1min", x1min);
@@ -394,6 +395,7 @@ Packages_t KHARMA::ProcessPackages(std::unique_ptr<ParameterInput> &pin)
     } else if (b_field_solver == "flux_ct") {
         t_b_field = tl.AddTask(t_grmhd, KHARMA::AddPackage, packages, B_FluxCT::Initialize, pin.get());
     } else {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::invalid_argument("Invalid solver! Must be e.g., flux_ct, face_ct, cd, cleanup...");
     }
     // Cleanup for the B field, using an elliptic solve for eliminating divB

--- a/kharma/kharma_utils.hpp
+++ b/kharma/kharma_utils.hpp
@@ -52,7 +52,10 @@ template<typename ... Args>
 std::string string_format( const std::string& format, Args ... args )
 {
     size_t size = snprintf( nullptr, 0, format.c_str(), args ... ) + 1; // Extra space for '\0'
-    if( size <= 0 ){ throw std::runtime_error( "Error during formatting." ); }
+    if( size <= 0 ) {
+        std::cout << std::endl; // flush messages in output buffer before we error
+        throw std::runtime_error( "Error during formatting." );
+    }
     std::unique_ptr<char[]> buf( new char[ size ] ); 
     snprintf( buf.get(), size, format.c_str(), args ... );
     return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside

--- a/kharma/prob/emhd/conducting_atmosphere.cpp
+++ b/kharma/prob/emhd/conducting_atmosphere.cpp
@@ -94,11 +94,13 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
     fp_rho = fopen(fode_rho, "r");
     fp_u   = fopen(fode_u,   "r");
     if (fp_r == NULL || fp_rho == NULL || fp_u == NULL) {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Could not open conducting atmosphere solution!");
     }
     if (use_emhd) {
         fp_q = fopen(fode_q, "r");
         if (fp_q == NULL) {
+            std::cout << std::endl; // flush messages in output buffer before we error
             throw std::runtime_error("Could not open conducting atmosphere solution!");
         }
     }

--- a/kharma/prob/emhd/emhdshock.hpp
+++ b/kharma/prob/emhd/emhdshock.hpp
@@ -105,6 +105,7 @@ TaskStatus InitializeEMHDShock(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
         fp_dP  = fopen(fbvp_dP,  "r");
 
         if (fp_rho == NULL || fp_u == NULL || fp_u1 == NULL || fp_q == NULL || fp_dP == NULL) {
+            std::cout << std::endl; // flush messages in output buffer before we error
             throw std::runtime_error("Could not open conducting atmosphere solution!");
         }
 

--- a/kharma/prob/problem.cpp
+++ b/kharma/prob/problem.cpp
@@ -129,6 +129,7 @@ void KHARMA::ProblemGenerator(MeshBlock *pmb, ParameterInput *pin)
 
     // If we didn't initialize a problem, yell
     if (status != TaskStatus::complete) {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::invalid_argument("Invalid or incomplete problem: "+prob);
     }
 

--- a/kharma/prob/resize_restart.cpp
+++ b/kharma/prob/resize_restart.cpp
@@ -99,6 +99,7 @@ void ReadIharmRestartHeader(std::string fname, ParameterInput *pin)
         hdf5_read_single_val(&Rin, "Rin", H5T_IEEE_F64LE);
         hdf5_read_single_val(&Rout, "Rout", H5T_IEEE_F64LE);
     } else {
+        std::cout << std::endl; // flush messages in output buffer before we error
         throw std::runtime_error("Unknown restart file type!");
     }
 

--- a/kharma/prob/seed_B.cpp
+++ b/kharma/prob/seed_B.cpp
@@ -349,6 +349,7 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
                 B_CT::EdgeCurl<F2,2>(rc, A, B_Uf, domain);
                 B_CT::EdgeCurl<F3,2>(rc, A, B_Uf, domain);
             } else {
+                std::cout << std::endl; // flush messages in output buffer before we error
                 throw std::runtime_error("Must initialize 1D field directly!");
             }
             B_CT::BlockUtoP(rc, domain);
@@ -373,6 +374,7 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
                     }
                 );
             } else {
+                std::cout << std::endl; // flush messages in output buffer before we error
                 throw std::runtime_error("Must initialize 1D field directly!");
             }
 
@@ -455,6 +457,7 @@ TaskStatus SeedBField(MeshData<Real> *md, ParameterInput *pin)
         } else if (b_field_type == "shock_tube") {
             status = SeedBFieldType<BSeedType::shock_tube>(rc, pin);
         } else {
+            std::cout << std::endl; // flush messages in output buffer before we error
             throw std::invalid_argument("Magnetic field seed type not supported: " + b_field_type);
         }
     }

--- a/pars/tori_3d/sane.par
+++ b/pars/tori_3d/sane.par
@@ -1,6 +1,7 @@
 # SANE ("Standard and Normal Evolution" i.e. not Magnetically Arrested).
 # Similar to "v5" library parameters w/adiabatic index 5/3,
 # and a larger disk (rin=10/rmax=20)
+# Updated for low floors and appropriate floor frame for Kastaun inverter
 
 
 <parthenon/job>
@@ -64,7 +65,9 @@ inner_x2 = reflecting
 outer_x2 = reflecting
 
 <floors>
-# Minimal floors, applied in the default Normal Observer frame
+# Minimal floors, leveraging inversion recovery.
+# Normal frame is now the only supported injection frame --
+# material added is so minimal that drag effects are negligible
 rho_min_geom = 1e-6
 u_min_geom   = 1e-8
 


### PR DESCRIPTION
A detailed explanation about the Kastaun inverter requiring normal frame floors was not printed in kharma/floors/floors.cpp before the error was thrown and the program terminated, making the error itself a little confusing. This issue is fixed in c57b079103e324b58361067f5198bd0554495c02

I then implemented the same idea before every `throw` statement, repository-wide in 0b15e7aa0722d7ff5fd4b61b14c45c444de9764f

I ran a build, which had no errors, so the above changes compile.

The last commit adds some documentation of the Kastaun --> normal frame requirement in the SANE param file.