### PR TITLE
Improve formatting toolchain (bugfixes, new pre-commit, etc)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+###########################################################################
+# KHARMA repo pre-commit:
+#
+# Devolopers should run the following to use this:
+#
+#    git config core.hooksPath .githooks
+#
+# git will then only look in the .githooks directory
+# for hooks, so if you have a custom hook for your workflow
+# in the hidden directory, either move it to .githooks
+# and set a local ignore policy in '.git/info/exclude',
+# or use the forwarding steps shown at the end of this
+# script (#2)
+#
+###########################################################################
+
+
+# 1. Run global rules
+echo "Running global pre-commit rules..."
+
+# pre-commit runs from repo root by default,
+# so run the formatter script on everything:
+export KDEV_FORMAT_STAGED=1
+./scripts/format.sh
+unset KDEV_FORMAT_STAGED
+
+# Then need to re-stage so that the formatted version is committed.
+# (The xargs insertion brackets '{}' are helpful if there are no cpp/hpp
+#  files being added, they will be left as-is)
+git diff --staged --name-only --diff-filter=ACMR -z -- \
+    'kharma/**.[ch]pp' 'tests/**.[ch]pp' \
+    | xargs -I {} -0 -t git add {}
+
+# 2. Forward execution to the local repository hook if it exists
+# (credit: Google AI search "git config core hooksPath multiple"
+#  for this forwarding idea)
+if [ -f "./.git/hooks/pre-commit" ]; then
+    echo "Running local repository pre-commit rules..."
+    "./.git/hooks/pre-commit" "$@" || exit 1
+fi

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -25,4 +25,7 @@ jobs:
             packages: |
                clang-format==19.1.7
         - name: check formatting
-          run: git ls-files -z 'kharma/**/*.cpp' 'kharma/**/*.hpp' 'tests/**/*.cpp' 'tests/**/*.hpp' | xargs -0 clang-format -style=file -i && git diff --exit-code --ignore-submodules
+          run: |
+            git ls-files -z 'kharma/**.[ch]pp' 'tests/**.[ch]pp' |
+              xargs -I {} -0 -t clang-format -style=file -i {} \
+              && git diff --exit-code --ignore-submodules

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ Further information can be found on the [wiki page](https://github.com/parthenon
 ## Hacking
 KHARMA has some documentation for developers on the [wiki](https://github.com/parthenon-hpc-lab/kharma/wiki).  The docs cover some quirks of coding in C++, in particular with Kokkos/GPU programming, and in particular with Parthenon.
 
+KHARMA has a desired formatting standard, so developers should configure
+their local clone to use the global `pre-commit` and other
+hooks which the repository defines. Just run:
+```
+git config --local core.hooksPath .githooks
+```
+If you also need custom local hooks for your workflow, see the comments
+in `.githooks/pre-commit`. The `pre-commit` will format files as they are
+changed or added. To apply formatting to existing code, e.g. many commits
+in a branch before the `pre-commit` hook was configured, use `scripts/format.sh`.
+Formatting is necessary or the GitHub Actions will flag problems on pull-requests
+to `stable` or `dev` branches.
+
 ## Licenses
 KHARMA is made available under the BSD 3-clause license included in each file and in the file LICENSE at the root of this repository.
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -43,6 +43,27 @@ echo "Note we assume clang format version ${TARGET_CF_VRSN}."
 echo "You are using ${CF_VRSN}."
 echo "If these differ, results may not be stable."
 
-echo "Formatting..."
-git ls-files -z 'kharma/**/*.cpp' 'kharma/**/*.hpp' 'tests/**/*.cpp' 'tests/**/*.hpp' | xargs -0 ${CFM} -style=file -i
+
+xargs_command="-I {} -0 -t ${CFM} -style=file -i {}"
+# (The xargs insertion brackets '{}' are helpful if there are no cpp/hpp
+#  files being added, they will be left as-is and avoid error messages)
+
+if [ -n "$KDEV_FORMAT_STAGED" ]; then
+    echo "Formatting staged files..."
+    git diff --staged --name-only --diff-filter=ACMR -z \
+        'kharma/**.[ch]pp' 'tests/**.[ch]pp' |
+        xargs $xargs_command
+
+elif [ -n "$KDEV_FORMAT_TRACKED" ]; then
+    echo "Formatting tracked files..."
+    git ls-files --cached -z 'kharma/**.[ch]pp' 'tests/**.[ch]pp' |
+        xargs $xargs_command
+
+else
+    # format both tracked and untracked cpp/hpp files in our directories.
+    # git ls-files seemed more reliable here than ls or find.
+    echo "Formatting all files..."
+    git ls-files --cached --other -z 'kharma/**.[ch]pp' 'tests/**.[ch]pp' |
+        xargs $xargs_command
+fi
 echo "...Done"


### PR DESCRIPTION
Fix pattern matching in `.github/workflows/formatting.yml` and `scripts/format.sh` to also include files at the main level of `kharma` and `tests` directories: before it would match `kharma/folder/some.cpp` but not `kharma/top_level.hpp`. **Warning**: this means the top level files are still unformatted on `dev` and `stable`, which may cause grief if these CI modifications are merged. I'm NOT going to include a format of those files in this branch so that if we need to do the "son-and-dance" around formatting/merging, the pre-format commit will also have all the needed script tooling present, just not run yet.

Adjust format.sh to support different modes of operation:
1. Format staged files, including added files new in that commit (pre-commit support)
2. Format tracked files, already in version control.
3. [default] Format all files, also getting any new untracked ones. The first two modes are obtained by exporting `KDEV_FORMAT_STAGED` or `KDEV_FORMAT_TRACKED` in the environment.

Add new .githooks directory and pre-commit hook to do formatting: run the format script in staged-mode, then add the format-related changes to the commit as well.

Document the formatting and hook configuration required in the README. Unfortunately there's no way to force hook configuration particularly, other than through the CI pipelines failing pull-requests, and that incentivizing authors to format the code themselves by using the hook.